### PR TITLE
Document CLI PATH setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ python3 -m venv .venv
 .venv/bin/pip install "git+https://github.com/ViktorOgnev/kaiten-cli.git"
 ```
 
+### Проверка установки
+
+```bash
+kaiten --version
+kaiten --help
+kaiten agent-help
+kaiten search-tools cards
+```
+
 ### Если команда `kaiten` не найдена
 
 `uv tool` и `pipx` устанавливают исполняемые файлы в отдельный каталог. Если
@@ -61,15 +70,6 @@ source ~/.bashrc
 ```bash
 pipx ensurepath
 exec "$SHELL" -l
-```
-
-### Проверка установки
-
-```bash
-kaiten --version
-kaiten --help
-kaiten agent-help
-kaiten search-tools cards
 ```
 
 ### Skills для LLM и агентов

--- a/README.md
+++ b/README.md
@@ -28,6 +28,41 @@ python3 -m venv .venv
 .venv/bin/pip install "git+https://github.com/ViktorOgnev/kaiten-cli.git"
 ```
 
+### Если команда `kaiten` не найдена
+
+`uv tool` и `pipx` устанавливают исполняемые файлы в отдельный каталог. Если
+после установки shell отвечает `bash: kaiten: command not found`, добавьте этот
+каталог в `PATH`:
+
+Для установки через `uv`:
+
+```bash
+uv tool update-shell
+exec "$SHELL" -l
+```
+
+Если команда всё ещё не находится, проверьте каталог и добавьте его вручную:
+
+```bash
+uv tool dir --bin
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Чтобы сохранить настройку для следующих терминалов, добавьте эту строку в
+`~/.bashrc` или `~/.zshrc`, затем перезапустите shell:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Для установки через `pipx` используйте:
+
+```bash
+pipx ensurepath
+exec "$SHELL" -l
+```
+
 ### Проверка установки
 
 ```bash


### PR DESCRIPTION
## Что изменилось

- добавлена инструкция для случаев, когда после установки `uv` или `pipx` команда `kaiten` не находится;
- описаны `uv tool update-shell`, `pipx ensurepath` и ручная настройка `PATH`.

## Зачем

Пользователь может успешно установить CLI, но получить `bash: kaiten: command not found`, если каталог с исполняемыми файлами не добавлен в `PATH`.

## Проверка

- `git diff --check`
