### PR TITLE
Add read-only policy to Kaiten profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ python3 -m venv .venv
 .venv/bin/pip install "git+https://github.com/ViktorOgnev/kaiten-cli.git"
 ```
 
+### Проверка установки
+
+```bash
+kaiten --version
+kaiten --help
+kaiten agent-help
+kaiten search-tools cards
+```
+
 ### Если команда `kaiten` не найдена
 
 `uv tool` и `pipx` устанавливают исполняемые файлы в отдельный каталог. Если
@@ -61,15 +70,6 @@ source ~/.bashrc
 ```bash
 pipx ensurepath
 exec "$SHELL" -l
-```
-
-### Проверка установки
-
-```bash
-kaiten --version
-kaiten --help
-kaiten agent-help
-kaiten search-tools cards
 ```
 
 ### Skills для LLM и агентов

--- a/README.md
+++ b/README.md
@@ -28,6 +28,41 @@ python3 -m venv .venv
 .venv/bin/pip install "git+https://github.com/ViktorOgnev/kaiten-cli.git"
 ```
 
+### Если команда `kaiten` не найдена
+
+`uv tool` и `pipx` устанавливают исполняемые файлы в отдельный каталог. Если
+после установки shell отвечает `bash: kaiten: command not found`, добавьте этот
+каталог в `PATH`:
+
+Для установки через `uv`:
+
+```bash
+uv tool update-shell
+exec "$SHELL" -l
+```
+
+Если команда всё ещё не находится, проверьте каталог и добавьте его вручную:
+
+```bash
+uv tool dir --bin
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+Чтобы сохранить настройку для следующих терминалов, добавьте эту строку в
+`~/.bashrc` или `~/.zshrc`, затем перезапустите shell:
+
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Для установки через `pipx` используйте:
+
+```bash
+pipx ensurepath
+exec "$SHELL" -l
+```
+
 ### Проверка установки
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -312,6 +312,22 @@ kaiten profile add main --domain <company-subdomain-or-url> --token <api-token> 
 kaiten profile show
 ```
 
+Для профиля, который всегда должен блокировать удалённые мутации, добавьте
+`--read-only`:
+
+```bash
+kaiten profile add analyst \
+  --domain <company-subdomain-or-url> \
+  --token <api-token> \
+  --read-only \
+  --set-active
+```
+
+Настройка сохраняется в профиле и применяется для активного или явно выбранного
+через `--profile` профиля. Её можно снять командой `profile add` с
+`--no-read-only`. Глобальные `--read-only` и `KAITEN_CLI_READ_ONLY` по-прежнему
+включают read-only независимо от настройки профиля.
+
 `--domain` и `KAITEN_DOMAIN` принимают tenant (`company`), Kaiten URL (`https://company.kaiten.ru`) или custom host с портом для локальных/dev-инсталляций.
 
 Если нужен фиксированный TTL persistent cache для этого profile вместо default `auto`:

--- a/src/kaiten_cli/app.py
+++ b/src/kaiten_cli/app.py
@@ -840,7 +840,7 @@ def profile_group() -> None:
 
 @profile_group.command(
     "add",
-    help="Create or update a named profile with Kaiten domain, API token and cache defaults.",
+    help="Create or update a named profile with credentials, safety and cache defaults.",
     short_help="Create or update a profile.",
 )
 @click.argument("name", type=click.STRING, metavar="NAME")
@@ -857,6 +857,11 @@ def profile_group() -> None:
     "--sandbox/--no-sandbox",
     default=False,
     help="Deprecated compatibility metadata. Does not affect mutations or live-test gating.",
+)
+@click.option(
+    "--read-only/--no-read-only",
+    default=None,
+    help="Persist read-only policy for this profile; mutations remain blocked when it is selected.",
 )
 @click.option(
     "--cache-mode",
@@ -882,6 +887,7 @@ def profile_add_command(
     domain: str,
     token: str,
     sandbox: bool,
+    read_only: bool | None,
     cache_mode: str | None,
     cache_ttl_seconds: int | None,
     set_active: bool,
@@ -897,6 +903,7 @@ def profile_add_command(
                     domain=domain,
                     token=token,
                     sandbox=sandbox,
+                    read_only=read_only,
                     cache_mode=cache_mode,
                     cache_ttl_seconds=cache_ttl_seconds,
                     set_active=set_active,

--- a/src/kaiten_cli/models.py
+++ b/src/kaiten_cli/models.py
@@ -185,6 +185,7 @@ class ResolvedProfile:
     domain: str
     token: str
     sandbox: bool = False
+    read_only: bool = False
     source: str = "unknown"
     cache_mode: str = CACHE_MODE_AUTO
     cache_ttl_seconds: int = 60

--- a/src/kaiten_cli/profiles.py
+++ b/src/kaiten_cli/profiles.py
@@ -174,15 +174,20 @@ def add_profile(
     domain: str,
     token: str,
     sandbox: bool = False,
+    read_only: bool | None = None,
     set_active: bool = False,
     cache_mode: str | None = None,
     cache_ttl_seconds: int | None = None,
 ) -> dict[str, Any]:
     config = load_config()
+    existing = config.get("profiles", {}).get(name, {})
     profile = {
         "domain": normalize_profile_domain(domain),
         "token": token,
         "sandbox": sandbox,
+        "read_only": bool(existing.get("read_only", False))
+        if read_only is None
+        else read_only,
     }
     if cache_mode is not None:
         profile["cache_mode"] = _normalize_cache_mode(cache_mode)
@@ -237,6 +242,7 @@ def show_profile(name: str | None = None) -> dict[str, Any]:
             "active": False,
             "domain": None,
             "sandbox": False,
+            "read_only": False,
             "token_masked": None,
             "cache_mode": CACHE_MODE_AUTO,
             "cache_ttl_seconds": 60,
@@ -253,6 +259,7 @@ def sanitized_profile(name: str, raw: dict[str, Any], *, active: bool) -> dict[s
         "active": active,
         "domain": normalize_profile_domain(str(raw.get("domain", ""))),
         "sandbox": bool(raw.get("sandbox", False)),
+        "read_only": bool(raw.get("read_only", False)),
         "token_masked": redact_token(raw.get("token")),
         "cache_mode": _normalize_cache_mode(raw.get("cache_mode")),
         "cache_ttl_seconds": _normalize_cache_ttl_seconds(raw.get("cache_ttl_seconds")),
@@ -276,6 +283,7 @@ def resolve_profile(
             domain=normalize_profile_domain(str(selected.get("domain", ""))),
             token=str(selected.get("token", "")),
             sandbox=bool(selected.get("sandbox", False)),
+            read_only=bool(selected.get("read_only", False)),
             source=source,
             cache_mode=_normalize_cache_mode(cache_mode_override or selected.get("cache_mode")),
             cache_ttl_seconds=_normalize_cache_ttl_seconds(

--- a/src/kaiten_cli/runtime/executor.py
+++ b/src/kaiten_cli/runtime/executor.py
@@ -109,12 +109,10 @@ async def execute_tool_with_diagnostics(
     read_only: bool | None = None,
 ) -> tuple[Any, ExecutionStats]:
     effective_read_only = read_only_enabled(read_only)
-    _emit_debug(
-        reporter,
-        f"safety: read_only={effective_read_only} mutation={tool.is_mutation} "
-        f"guarded={tool.runtime_behavior.enforce_mutation_guard}",
-    )
-    enforce_mutation_policy(tool, read_only=effective_read_only)
+    if effective_read_only:
+        # Preserve the existing fail-closed behavior for explicit/env read-only:
+        # a mutation is blocked before credentials or a network client are needed.
+        enforce_mutation_policy(tool, read_only=True)
     profile: ResolvedProfile | None = None
     context: ExecutionContext | None = None
     client: KaitenClient | None = None
@@ -129,8 +127,10 @@ async def execute_tool_with_diagnostics(
             "profile: "
             f"source={profile.source} name={profile.name or '-'} domain={profile.domain} "
             f"sandbox_metadata={profile.sandbox} cache_mode={profile.cache_mode} "
-            f"cache_ttl_seconds={profile.cache_ttl_seconds}",
+            f"cache_ttl_seconds={profile.cache_ttl_seconds} "
+            f"read_only={profile.read_only}",
         )
+        effective_read_only = effective_read_only or profile.read_only
         context = ExecutionContext.for_profile(profile, reporter=reporter)
         client = KaitenClient(
             domain=profile.domain,
@@ -142,6 +142,12 @@ async def execute_tool_with_diagnostics(
         )
     else:
         _emit_debug(reporter, "profile: not required for this command")
+    _emit_debug(
+        reporter,
+        f"safety: read_only={effective_read_only} mutation={tool.is_mutation} "
+        f"guarded={tool.runtime_behavior.enforce_mutation_guard}",
+    )
+    enforce_mutation_policy(tool, read_only=effective_read_only)
     path, query, body = build_request(tool, payload)
     request_path = request_path_for_tool(tool, path, client)
     timeout = timeout_for_tool(tool)

--- a/tests/test_executor_http.py
+++ b/tests/test_executor_http.py
@@ -326,6 +326,24 @@ async def test_read_only_environment_blocks_remote_mutation_before_http(config_e
     assert route.call_count == 0
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_read_only_profile_blocks_remote_mutation_before_http(config_env):
+    from kaiten_cli.profiles import add_profile
+
+    add_profile("safe", domain="prod-tenant", token="test-token", read_only=True, set_active=True)
+    route = respx.post("https://prod-tenant.kaiten.ru/api/latest/cards").mock(
+        return_value=Response(201, json={"id": 1})
+    )
+    tool = resolve_tool("cards.create")
+    payload = merge_inputs(tool, {"title": "Task", "board_id": 1})
+
+    with pytest.raises(MutationBlockedError, match="blocked by read-only mode"):
+        await execute_tool(tool, payload)
+
+    assert route.call_count == 0
+
+
 def test_read_only_policy_allows_local_snapshot_mutations():
     tool = resolve_tool("snapshot.delete")
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -208,6 +208,26 @@ def test_profile_add_and_resolve_cache_settings(config_env):
     assert resolved.cache_ttl_seconds == 120
 
 
+def test_profile_read_only_is_persisted_and_resolved(config_env):
+    added = add_profile(
+        "main", domain="sandbox", token="secret-token", read_only=True, set_active=True
+    )
+
+    assert added["read_only"] is True
+    assert show_profile()["read_only"] is True
+    assert list_profiles()[0]["read_only"] is True
+    assert resolve_profile().read_only is True
+
+
+def test_profile_update_without_read_only_flag_preserves_policy(config_env):
+    add_profile("main", domain="sandbox", token="secret-token", read_only=True, set_active=True)
+
+    updated = add_profile("main", domain="sandbox", token="new-token")
+
+    assert updated["read_only"] is True
+    assert resolve_profile().read_only is True
+
+
 def test_resolve_profile_cli_cache_overrides_profile_defaults(config_env):
     add_profile(
         "main",


### PR DESCRIPTION
## Что изменено

- добавлена сохраняемая настройка `read_only` для профилей Kaiten;
- добавлены параметры `profile add --read-only` и `--no-read-only`;
- read-only политика выбранного профиля автоматически блокирует удалённые мутации;
- настройка отображается в выводе профиля и описана в README;
- при обновлении профиля без указания флага существующая read-only настройка сохраняется.

## Зачем

Профиль можно использовать как постоянный предохранитель от случайных изменений в Kaiten. Это дополняет глобальные `--read-only` и `KAITEN_CLI_READ_ONLY`.

Настройка является защитой на уровне CLI, а не заменой серверным правам Kaiten. Для работы агента рекомендуется использовать отдельный API-токен с правами только на чтение.

## Проверки

- `uv run --extra test pytest -q`;
- `400 passed, 2 deselected`;
- `git diff --check`.

Несвязанные незатребованные файлы в PR не включались.
